### PR TITLE
Deadly, Small, 5x15 vs 2@20 getDifficulty test

### DIFF
--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -284,5 +284,12 @@ all =
                         Expect.equal (Just Medium) <|
                             getDifficulty (List.repeat 2 3) (List.repeat 2 100)
                 ]
+                , test "15 rugs of smothering are Deadly for 2 level 20s" <|
+                    -- 5x multiplier: 5(450xp x 15) >= 25400 Deadly
+                    \() ->
+                        Expect.equal (Just Deadly) <|
+                            getDifficulty (List.repeat 2 20) (List.repeat 15 450)
+                            -- TODO: move suites to distinct files. line >80^
+                ]
             ]
         ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -283,7 +283,7 @@ all =
                     \() ->
                         Expect.equal (Just Medium) <|
                             getDifficulty (List.repeat 2 3) (List.repeat 2 100)
-                ]
+
                 , test "15 rugs of smothering are Deadly for 2 level 20s" <|
                     -- 5x multiplier: 5(450xp x 15) >= 25400 Deadly
                     \() ->


### PR DESCRIPTION
This is a Pull Request. As the name implies, it is a request to have your changes "pulled" into the project so that they can be integrated by the primary author(s). It's the default method of collaboration for software projects on Github.

This message will autopopulate with the body of your commit message when you use the Github file editing feature to create a pull request directly from the project.

See the thread below for a demonstration of the normal PR workflow and some additional context to how this is used.

**Example that is also on the commit message**
Added the following getDifficulty test case:
- Two level 20 PCs
- 15 CR3 monsters for 5x multiplier against two player party (highest possible by RAW)
- Total monster XP is 33750, Deadly XP Threshold is 25400 for the party configuration
- Rugs of smothering for the lulz