### PR TITLE
MVP: add and remove party members and monsters

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -10,16 +10,28 @@ import Encounter exposing (..)
 main : Program Never Model Msg
 main =
     beginnerProgram
-        { model = Model 0 0 Nothing
+        { model = init
         , view = view
         , update = update
         }
 
 
 type alias Model =
-    { party : Int
-    , monster : Int
+    { party : Party
+    , monsters : Monsters
     , difficulty : Maybe Difficulty
+    }
+
+
+type alias Party =
+    { first : (String, Int)
+    , rest : List (String, Int)
+    }
+
+
+type alias Monsters =
+    { first : (String, Int)
+    , rest : List (String, Int)
     }
 
 
@@ -28,16 +40,28 @@ type Msg
     | ChangeParty String
 
 
+init : Model
+init =
+    Model
+        (Party ("", 0) [])
+        (Monsters ("", 0) [])
+        Nothing
+
+
 update : Msg -> Model -> Model
 update msg model =
+    let
+        monsters = model.monsters
+        party = model.party
+    in
     case msg of
         ChangeMonster value ->
             case String.toInt value of
                 Ok value ->
                     { model
-                    | monster = value
+                    | monsters = { monsters | first = ("", value) } 
                     , difficulty =
-                        getDifficulty [model.party] [value]
+                        getDifficulty [Tuple.second party.first] [value]
                     }
                 Err _ ->
                     model
@@ -46,9 +70,9 @@ update msg model =
             case String.toInt value of
                 Ok value ->
                     { model
-                    | party = value
+                    | party = { party | first = ("", value) }
                     , difficulty =
-                        getDifficulty [value] [model.monster]
+                        getDifficulty [value] [Tuple.second monsters.first]
                     }
                 Err _ ->
                     model
@@ -60,8 +84,8 @@ view model =
         [ h1 [] [ text "Encounter Calculator" ]
         , form []
             [ viewDifficulty model.difficulty
-            , viewParty <| toString model.party
-            , viewMonsters <| toString model.monster
+            , viewParty model.party
+            , viewMonsters model.monsters
             ]
         ]
 
@@ -78,36 +102,42 @@ viewDifficulty difficulty =
             ]
 
 
+viewParty : Party -> Html Msg
 viewParty party =
     div []
         [ h3 [] [ text "Party" ]
-        , label []
-            [ input
-                [ type_ "number"
-                , onChange ChangeParty
-                , value party
-                ]
-                []
+        , ul [] <|
+            viewEncounterMemberLi ChangeParty party.first ::
+            List.map (viewEncounterMemberLi ChangeParty) party.rest
             ]
-        ]
         -- TODO: dynamic party inputs
         -- TODO: show XP thresholds
 
 
-viewMonsters monster =
+viewMonsters : Monsters -> Html Msg
+viewMonsters monsters =
     div []
         [ h3 [] [ text "Monsters" ]
-        , label []
+        , ul [] <|
+            viewEncounterMemberLi ChangeMonster monsters.first ::
+            List.map (viewEncounterMemberLi ChangeMonster) monsters.rest
+        ]
+        -- TODO: dynamic monster inputs
+        -- TODO: show XP values (per monster/per encounter)
+
+
+viewEncounterMemberLi : (String -> Msg) -> (String, Int) -> Html Msg
+viewEncounterMemberLi msg (name, value) =
+    li []
+        [ label []
             [ input
                 [ type_ "number"
-                , onChange ChangeMonster
-                , value monster
+                , onChange msg
+                , Html.Attributes.value <| toString value
                 ]
                 []
             ]
         ]
-        -- TODO: dynamic monster inputs
-        -- TODO: show XP values (per monster/per encounter)
 
 
 onChange : (String -> Msg) -> Attribute Msg

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -102,6 +102,7 @@ view model =
         ]
 
 
+viewDifficulty : Maybe Difficulty -> Html Msg
 viewDifficulty difficulty =
     let
         difficultyString =

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -78,10 +78,28 @@ update msg model =
     in
         case msg of
             AddMonster ->
-                addMonster model
+                let
+                    monsters = model.monsters
+                    nextId = List.length model.monsters.rest + 1
+                in
+                    { model
+                    | monsters =
+                        { monsters
+                        | rest = monsters.rest ++ [defaultMonster nextId]
+                        }
+                    }
 
             AddPartyMember ->
-                addPartyMember model
+                let
+                    party = model.party
+                    nextId = List.length model.party.rest + 1
+                in
+                    { model
+                    | party =
+                        { party
+                        | rest = party.rest ++ [defaultPartyMember nextId]
+                        }
+                    }
 
             ChangeMonster id xp ->
                 case String.toInt xp of
@@ -108,62 +126,30 @@ update msg model =
                         model
 
             RemoveMonster ->
-                removeMonster model
+    let
+        monsters = model.monsters
+    in
+        { model
+        | monsters =
+            { monsters
+                        | rest =
+                            List.take
+                                (List.length monsters.rest - 1)
+                                monsters.rest
+            }
+        }
 
             RemovePartyMember ->
-                removePartyMember model
-
-
-addMonster : Model -> Model
-addMonster model =
-    let
-        monsters = model.monsters
-        nextId = List.length model.monsters.rest + 1
-    in
-        { model
-        | monsters =
-            { monsters
-            | rest = monsters.rest ++ [defaultMonster nextId]
-            }
-        }
-
-
-addPartyMember : Model -> Model
-addPartyMember model =
-    let
-        party = model.party
-        nextId = List.length model.party.rest + 1
-    in
-        { model
-        | party =
-            { party
-            | rest = party.rest ++ [defaultPartyMember nextId]
-            }
-        }
-
-
-removeMonster : Model -> Model
-removeMonster model =
-    let
-        monsters = model.monsters
-    in
-        { model
-        | monsters =
-            { monsters
-            | rest = List.take (List.length monsters.rest - 1) monsters.rest
-            }
-        }
-
-
-removePartyMember : Model -> Model
-removePartyMember model =
     let
         party = model.party
     in
         { model
         | party =
             { party
-            | rest = List.take (List.length party.rest - 1) party.rest
+                        | rest =
+                            List.take
+                                (List.length party.rest - 1)
+                                party.rest
             }
         }
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -19,7 +19,6 @@ main =
 type alias Model =
     { party : Side
     , monsters : Side
-    , difficulty : Maybe Difficulty
     }
 
 
@@ -57,7 +56,7 @@ init =
                 [] ->
                     Side (defaultMonster 0) []
     in
-        Model party monsters Nothing
+        Model party monsters
 
 
 defaultPartyMember : Int -> (String, Int)
@@ -106,8 +105,6 @@ update msg model =
                     Ok xp ->
                         { model
                         | monsters = updateMember monsters id xp
-                        , difficulty =
-                            getDifficulty [Tuple.second party.first] [xp]
                         }
 
                     Err _ ->
@@ -118,8 +115,6 @@ update msg model =
                     Ok level ->
                         { model
                         | party = updateMember party id level
-                        , difficulty =
-                            getDifficulty [level] [Tuple.second monsters.first]
                         }
 
                     Err _ ->
@@ -175,23 +170,33 @@ view model =
     section []
         [ h1 [] [ text "Encounter Calculator" ]
         , form []
-            [ viewDifficulty model.difficulty
+            [ viewDifficulty model
             , viewParty model.party
             , viewMonsters model.monsters
             ]
         ]
 
 
-viewDifficulty : Maybe Difficulty -> Html Msg
-viewDifficulty difficulty =
+viewDifficulty : Model -> Html Msg
+viewDifficulty model =
     let
-        difficultyString =
+        levels =
+            [model.party.first] ++ model.party.rest
+                |> List.unzip
+                |> Tuple.second
+
+        xps =
+            [model.monsters.first] ++ model.monsters.rest
+                |> List.unzip
+                |> Tuple.second
+
+        difficultyString difficulty =
             case difficulty of
                 Just x  -> difficultyToString x ++ " encounter"
                 Nothing -> "Invalid encounter state"
     in
         div []
-            [ h2 [] [ text difficultyString ]
+            [ h2 [] [ text <| difficultyString <| getDifficulty levels xps ]
             ]
 
 


### PR DESCRIPTION
Added two pairs of add and remove buttons to both sides of the encounter calculator. There is a lower limit of at least one input on both sides with no upper limit.

This resolves #11 